### PR TITLE
feat: forward alteration repository for community PRs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,9 @@ inputs:
   db-alteration-target:
     description: "Alterations source branch"
     required: false
+  db-alteration-repository:
+    description: "Repository hosting the alterations branch. Defaults to the current repository; set to the PR head repo (e.g. a fork) to support community PRs."
+    required: false
   verbose:
     description: "Show all kinds of logs"
     type: boolean
@@ -95,9 +98,10 @@ runs:
 
     - name: DB Alteration
       if: ${{ inputs['db-alteration-target'] != '' }}
-      uses: logto-io/actions-run-db-alteration-steps@v1.0.0
+      uses: logto-io/actions-run-db-alteration-steps@v1.1.0
       with:
         branch: ${{ inputs['db-alteration-target'] }}
+        repository: ${{ inputs['db-alteration-repository'] }}
 
     - name: Run Logto
       working-directory: logto/


### PR DESCRIPTION
## Summary

- Add a new optional \`db-alteration-repository\` input.
- Forward it to the underlying [\`actions-run-db-alteration-steps\`](https://github.com/logto-io/actions-run-db-alteration-steps) step.
- Bump the inner action ref from \`v1.0.0\` → \`v1.1.0\` (which adds the matching \`repository\` input).

## Why

The \`alteration-compatibility-integration-test\` workflow in [logto-io/logto](https://github.com/logto-io/logto) fails for any PR opened from a fork because the inner alterations checkout points at \`github.repository\` (= the base repo), where the contributor's branch doesn't exist. Forwarding the head fork's repo name unblocks community PRs.

## Depends on

- [ ] logto-io/actions-run-db-alteration-steps#3 — must be merged + released as \`v1.1.0\` before this PR can merge.

## Rollout

Backward compatible: existing callers that don't pass \`db-alteration-repository\` get the prior behavior (defaults to the current repo) since the inner action's new input also defaults to \`github.repository\`. Suggest cutting \`v4.1.0\` after merge; then [logto-io/logto](https://github.com/logto-io/logto) bumps the workflow and starts passing the new input.

## Test plan

- [ ] Verify same-repo PR still works on \`logto-io/logto\` master (no behavior change)
- [ ] After release + workflow bump in \`logto-io/logto\`, verify a community PR (fork) passes \`alteration-compatibility-integration-test\` end-to-end